### PR TITLE
feat: Make reference optional in MUSHRA pages

### DIFF
--- a/configs/mushra_no_reference.yaml
+++ b/configs/mushra_no_reference.yaml
@@ -1,0 +1,38 @@
+# test config mushra page, waveform, 11 conditions, no reference
+
+
+testname: MUSHRA without reference
+testId: mushra_no_reference
+bufferSize: 2048
+stopOnErrors: true
+showButtonPreviousPage: true
+remoteService: service/write.php
+
+
+pages:
+
+    - type: mushra
+      id: trial1
+      name: Mono Trial without reference
+      content: test description
+      showWaveform: true
+      stimuli:
+          C1: configs/resources/audio/mono_c1.wav
+          C2: configs/resources/audio/mono_c2.wav
+          C3: configs/resources/audio/mono_c3.wav
+          C4: configs/resources/audio/mono_c1.wav
+          C5: configs/resources/audio/mono_c2.wav
+          C6: configs/resources/audio/mono_c3.wav
+          C7: configs/resources/audio/mono_c1.wav
+          C8: configs/resources/audio/mono_c2.wav
+          C9: configs/resources/audio/mono_c3.wav
+          C10: configs/resources/audio/mono_c1.wav
+          C11: configs/resources/audio/mono_c2.wav
+
+
+    - type: finish
+      name: Thank you
+      content: Thank you for attending
+      popupContent: Your results were sent. Goodbye and have a nice day
+      showResults: true
+      writeResults: true

--- a/lib/webmushra/audio/MushraAudioControl.js
+++ b/lib/webmushra/audio/MushraAudioControl.js
@@ -41,26 +41,34 @@ function MushraAudioControl(_audioContext, _bufferSize, _reference, _conditions,
   //listeners
   this.eventListeners = [];
 
-  this.conditions[this.conditions.length] = this.reference;  
+  if (this.reference) {
+    this.conditions[this.conditions.length] = this.reference;
   
-  // add anchors
-  if (this.createAnchor35) {
-    this.conditions[this.conditions.length] = this.createLowerAnchor35(this.reference.getAudioBuffer());
-  }
-  if (this.createAnchor70) {
-    this.conditions[this.conditions.length] = this.createLowerAnchor70(this.reference.getAudioBuffer());
+    // add anchors
+    if (this.createAnchor35) {
+      this.conditions[this.conditions.length] = this.createLowerAnchor35(this.reference.getAudioBuffer());
+    }
+    if (this.createAnchor70) {
+      this.conditions[this.conditions.length] = this.createLowerAnchor70(this.reference.getAudioBuffer());
+    }
   }
 
   if (_randomize !== false) { // default is true
     shuffle(this.conditions);
   }
   
-  // Use reference length to allow full reference playback
-  var referenceLength = this.reference.getAudioBuffer().length;
+  var firstStimulus = this.reference ? this.reference : this.conditions[0];
+  if (!firstStimulus) {
+    this.errorHandler.sendError("No stimuli available to configure MushraAudioControl.");
+    return;
+  }
 
-  this.audioLoopEnd = referenceLength;  // Use reference length instead of minimum
-  this.audioMaxPosition = referenceLength;
-  this.audioSampleRate = this.reference.getAudioBuffer().sampleRate;
+  // Use reference length to allow full reference playback
+  var firstStimulusLength = firstStimulus.getAudioBuffer().length;
+
+  this.audioLoopEnd = firstStimulusLength;  // Use reference length instead of minimum
+  this.audioMaxPosition = firstStimulusLength;
+  this.audioSampleRate = firstStimulus.getAudioBuffer().sampleRate;
 }
 
 
@@ -162,7 +170,8 @@ MushraAudioControl.prototype.initAudio = function() {
   this.dummyBufferSource.loop = true;
   this.dummyBufferSource.buffer = this.audioContext.createBuffer(1, this.bufferSize, this.audioContext.sampleRate);
 
-  var channelCount = (this.reference.getAudioBuffer().numberOfChannels > 2) ?  this.audioContext.destination.channelCount : this.reference.getAudioBuffer().numberOfChannels;   
+  var firstStimulus = this.reference ? this.reference : this.conditions[0];
+  var channelCount = (firstStimulus.getAudioBuffer().numberOfChannels > 2) ?  this.audioContext.destination.channelCount : firstStimulus.getAudioBuffer().numberOfChannels;
   this.scriptNode = this.audioContext.createScriptProcessor(this.bufferSize, 1, channelCount);
   this.scriptNode.onaudioprocess = (function(audioProcessingEvent) { this.process(audioProcessingEvent); }).bind(this);
   
@@ -233,7 +242,7 @@ MushraAudioControl.prototype.process = function(audioProcessingEvent) {
   var fadingActive = null;
   var loopingActive = this.audioLoopingActive;
   
-  for (channel = 0; channel < this.reference.getAudioBuffer().numberOfChannels; ++channel) {
+  for (channel = 0; channel < outputBuffer.numberOfChannels; ++channel) {
     outputData = outputBuffer.getChannelData(channel);
     inputData = audioBuffer.getChannelData(channel);
     currentPosition = this.audioCurrentPosition; 
@@ -428,6 +437,9 @@ MushraAudioControl.prototype.getActiveStimulus = function() {
 };
 
 MushraAudioControl.prototype.playReference = function() {
+  if (!this.reference) {
+    return;
+  }
   this.play(this.reference, true);
   if (this.switchBack) {
     this.setPosition(0, false);

--- a/lib/webmushra/misc/MushraValidator.js
+++ b/lib/webmushra/misc/MushraValidator.js
@@ -54,24 +54,28 @@ MushraValidator.prototype.checkStimulusDuration = function(_stimulus) {
   return true;
 };
 
-MushraValidator.prototype.checkConditionConsistency = function(_reference, _conditions) {
-  var sampleRate = _reference.getAudioBuffer().sampleRate;
-  var length = _reference.getAudioBuffer().length;
-  var numberOfChannels = _reference.getAudioBuffer().numberOfChannels;
+MushraValidator.prototype.checkConditionConsistency = function(_stimuli) {
+  if (!_stimuli || _stimuli.length < 2) {
+    return true; // Nothing to compare
+  }
+  var firstStimulus = _stimuli[0];
+  var sampleRate = firstStimulus.getAudioBuffer().sampleRate;
+  var length = firstStimulus.getAudioBuffer().length;
+  var numberOfChannels = firstStimulus.getAudioBuffer().numberOfChannels;
   var noError = true;
-  for (var i = 0; i < _conditions.length; ++i) {
-    if (sampleRate != _conditions[i].getAudioBuffer().sampleRate) {
-      this.errorHandler.sendError("Reference/Conditions have different sample rates.");
+  for (var i = 1; i < _stimuli.length; ++i) {
+    if (sampleRate != _stimuli[i].getAudioBuffer().sampleRate) {
+      this.errorHandler.sendError("Stimuli have different sample rates. (" + firstStimulus.id + " vs " + _stimuli[i].id + ")");
       noError = false;
     }
     // length
-    if (length != _conditions[i].getAudioBuffer().length) {
-      this.errorHandler.sendError("Reference/Conditions have different (sample) lengths.");
+    if (length != _stimuli[i].getAudioBuffer().length) {
+      this.errorHandler.sendError("Stimuli have different (sample) lengths. (" + firstStimulus.id + " vs " + _stimuli[i].id + ")");
       noError = false;
     }
     // numberOfChannels
-    if (numberOfChannels != _conditions[i].getAudioBuffer().numberOfChannels) {
-      this.errorHandler.sendError("Reference/Conditions have different numbers of channels.");
+    if (numberOfChannels != _stimuli[i].getAudioBuffer().numberOfChannels) {
+      this.errorHandler.sendError("Stimuli have different numbers of channels. (" + firstStimulus.id + " vs " + _stimuli[i].id + ")");
       noError = false;
     }
   }

--- a/lib/webmushra/pages/MushraPage.js
+++ b/lib/webmushra/pages/MushraPage.js
@@ -29,8 +29,12 @@ function MushraPage(_pageManager, _audioContext, _bufferSize, _audioFileLoader, 
   for (var key in this.pageConfig.stimuli) {
     this.conditions[this.conditions.length] = new Stimulus(key, this.pageConfig.stimuli[key]);
   }
-  this.reference = new Stimulus("reference", this.pageConfig.reference);
-  this.audioFileLoader.addFile(this.reference.getFilepath(), (function (_buffer, _stimulus) { _stimulus.setAudioBuffer(_buffer); }), this.reference);
+  if (this.pageConfig.reference) {
+    this.reference = new Stimulus("reference", this.pageConfig.reference);
+    this.audioFileLoader.addFile(this.reference.getFilepath(), (function (_buffer, _stimulus) { _stimulus.setAudioBuffer(_buffer); }), this.reference);
+  } else {
+    this.reference = null;
+  }
   for (var i = 0; i < this.conditions.length; ++i) {
     this.audioFileLoader.addFile(this.conditions[i].getFilepath(), (function (_buffer, _stimulus) { _stimulus.setAudioBuffer(_buffer); }), this.conditions[i]);
   }
@@ -57,15 +61,22 @@ MushraPage.prototype.init = function () {
   
   if (this.pageConfig.strict !== false) {
     this.mushraValidator.checkNumConditions(this.conditions);
-    this.mushraValidator.checkStimulusDuration(this.reference);
+    if(this.reference) {
+      this.mushraValidator.checkStimulusDuration(this.reference);
+    }
   }
-  
-  this.mushraValidator.checkNumChannels(this.audioContext, this.reference);
+
+  var allStimuli = this.conditions.slice();
+  if (this.reference) {
+    this.mushraValidator.checkNumChannels(this.audioContext, this.reference);
+    allStimuli.unshift(this.reference);
+  }
+
 	var i;
   for (i = 0; i < this.conditions.length; ++i) {
     this.mushraValidator.checkSamplerate(this.audioContext.sampleRate, this.conditions[i]);
   }
-  this.mushraValidator.checkConditionConsistency(this.reference, this.conditions);
+  this.mushraValidator.checkConditionConsistency(allStimuli);
 
   this.mushraAudioControl = new MushraAudioControl(this.audioContext, this.bufferSize, this.reference, this.conditions, this.errorHandler, this.pageConfig.createAnchor35, this.pageConfig.createAnchor70, this.pageConfig.randomize, this.pageConfig.switchBack);
   this.mushraAudioControl.addEventListener((function (_event) {
@@ -227,8 +238,10 @@ MushraPage.prototype.render = function (_parent) {
   var trConditionNames = $("<tr></tr>");
   tableMushra.append(trConditionNames);
 
-  var tdConditionNamesReference = $("<td>" + this.pageManager.getLocalizer().getFragment(this.language, 'reference') + "</td>");
-  trConditionNames.append(tdConditionNamesReference);
+  if (this.reference) {
+    var tdConditionNamesReference = $("<td>" + this.pageManager.getLocalizer().getFragment(this.language, 'reference') + "</td>");
+    trConditionNames.append(tdConditionNamesReference);
+  }
 
   var tdConditionNamesScale = $("<td id='conditionNameScale'></td>");
   trConditionNames.append(tdConditionNamesScale);
@@ -259,11 +272,13 @@ MushraPage.prototype.render = function (_parent) {
   var trConditionPlay = $("<tr></tr>");
   tableMushra.append(trConditionPlay);
 
-  var tdConditionPlayReference = $("<td></td>");
-  trConditionPlay.append(tdConditionPlayReference);
+  if (this.reference) {
+    var tdConditionPlayReference = $("<td></td>");
+    trConditionPlay.append(tdConditionPlayReference);
 
-  var buttonPlayReference = $("<button data-theme='a' id='buttonReference' data-role='button' class='audioControlElement' onclick='" + this.pageManager.getPageVariableName(this) + ".btnCallbackReference()' style='margin : 0 auto;'>" + this.pageManager.getLocalizer().getFragment(this.language, 'playButton') + "</button>");
-  tdConditionPlayReference.append(buttonPlayReference);
+    var buttonPlayReference = $("<button data-theme='a' id='buttonReference' data-role='button' class='audioControlElement' onclick='" + this.pageManager.getPageVariableName(this) + ".btnCallbackReference()' style='margin : 0 auto;'>" + this.pageManager.getLocalizer().getFragment(this.language, 'playButton') + "</button>");
+    tdConditionPlayReference.append(buttonPlayReference);
+  }
 
   var tdConditionPlayScale = $("<td></td>");
   trConditionPlay.append(tdConditionPlayScale);
@@ -283,8 +298,10 @@ MushraPage.prototype.render = function (_parent) {
   var trConditionRatings = $("<tr id='tr_ConditionRatings'></tr>");
   tableMushra.append(trConditionRatings);
 
-  var tdConditionRatingsReference = $("<td id='refCanvas'></td>");
-  trConditionRatings.append(tdConditionRatingsReference);
+  if (this.reference) {
+    var tdConditionRatingsReference = $("<td id='refCanvas'></td>");
+    trConditionRatings.append(tdConditionRatingsReference);
+  }
 
   var tdConditionRatingsScale = $("<td id='spaceForScale'></td>");
   trConditionRatings.append(tdConditionRatingsScale);
@@ -302,9 +319,11 @@ MushraPage.prototype.render = function (_parent) {
   this.macic = new MushraAudioControlInputController(this.mushraAudioControl, this.pageConfig.enableLooping);
   this.macic.bind(); 
 
-this.waveformVisualizer = new WaveformVisualizer(this.pageManager.getPageVariableName(this) + ".waveformVisualizer", tdRight, this.reference, this.pageConfig.showWaveform, this.pageConfig.enableLooping, this.mushraAudioControl);
-  this.waveformVisualizer.create();
-  this.waveformVisualizer.load();
+  if (this.reference) {
+    this.waveformVisualizer = new WaveformVisualizer(this.pageManager.getPageVariableName(this) + ".waveformVisualizer", tdRight, this.reference, this.pageConfig.showWaveform, this.pageConfig.enableLooping, this.mushraAudioControl);
+    this.waveformVisualizer.create();
+    this.waveformVisualizer.load();
+  }
 };
 
 MushraPage.prototype.pause = function() {
@@ -375,7 +394,10 @@ MushraPage.prototype.renderCanvas = function(_parentId) {
   canvas.style.zIndex = 0;
   canvas.setAttribute("id","mushra_canvas");
   parent.get(0).appendChild(canvas);
-  $('#mushra_canvas').offset({top: $('#refCanvas').offset().top, left : $('#refCanvas').offset().left});
+  var refCanvas = $('#refCanvas');
+  if (refCanvas.length > 0) {
+    $('#mushra_canvas').offset({top: refCanvas.offset().top, left : refCanvas.offset().left});
+  }
   canvas.height = parent.get(0).offsetHeight - (parent.get(0).offsetHeight - $('#tr_ConditionRatings').height());
   canvas.width = parent.get(0).offsetWidth;
 
@@ -427,7 +449,9 @@ MushraPage.prototype.renderCanvas = function(_parentId) {
   canvasContext.font = "1.25em Calibri";
   canvasContext.textBaseline = "middle";
   canvasContext.textAlign = "center";
-  var xLetters = $("#refCanvas").width() + ($("#spaceForScale").width() + canvasContext.measureText("1 ").width) / 2.0;
+  var refCanvas = $('#refCanvas');
+  var refCanvasWidth = (refCanvas.length > 0) ? refCanvas.width() : 0;
+  var xLetters = refCanvasWidth + ($("#spaceForScale").width() + canvasContext.measureText("1 ").width) / 2.0;
 
   canvasContext.fillText(this.pageManager.getLocalizer().getFragment(this.language, 'excellent'),xLetters , prevScalesHeight * 0.1 + YfirstLine);
   canvasContext.fillText(this.pageManager.getLocalizer().getFragment(this.language, 'good'), xLetters, prevScalesHeight * 0.3 + YfirstLine);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "webMUSHRA",
       "version": "1.4.3",
       "license": "SEE LICENSE IN LICENSE.txt",
       "devDependencies": {


### PR DESCRIPTION
This change makes the `reference` field in the MUSHRA page configuration optional.

- If the `reference` is not provided in the YAML config, the UI will not render the reference track elements (play button, label, etc.).
- The audio control and validation logic now handle cases where the reference is missing, falling back to the first condition for audio properties if needed.
- `MushraValidator.js` was updated to make `checkConditionConsistency` more generic.
- A new config file `mushra_no_reference.yaml` has been added to test this functionality.